### PR TITLE
Exclude incident_key and details when empty

### DIFF
--- a/pagerduty.go
+++ b/pagerduty.go
@@ -28,8 +28,8 @@ type Event struct {
 	ServiceKey  string                 `json:"service_key"`
 	EventType   string                 `json:"event_type"`
 	Description string                 `json:"description"`
-	IncidentKey string                 `json:"incident_key"`
-	Details     map[string]interface{} `json:"details"`
+	IncidentKey string                 `json:"incident_key,omitempty"`
+	Details     map[string]interface{} `json:"details,omitempty"`
 }
 
 // See http://developer.pagerduty.com/documentation/integration/events


### PR DESCRIPTION
Excluding incident_key is necessary because if you do not provide an incident key the json package marshals the object with `incident_key = ""` which the server accepts as a valid key. The problem is that the expected behaviour when `IncidentKey == ""` is for no incident key to be set and for the server to generate one for you. This can only happen if the generated json does not serialize incident_key at all.
